### PR TITLE
Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -169,6 +169,7 @@ RUN pip install redis
 # triplexer
 COPY ["common.py", "conf.yaml", "microrna_org.py", "triplexer",  "/srv/"]
 COPY ["data", "/srv/data"]
+ENV PATH="/srv:${PATH}"
 WORKDIR /srv
 USER user
 CMD ["bash"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,11 +2,9 @@ version: '3'
 services:
 
   pipeline:
-    image: triplexer-pipeline:latest
-    build:
-      context: .
     container_name: triplexer-pipeline
-    hostname: triplexer-pipeline
+    image: quay.io/bagnacan/triplexer:latest
+    hostname: triplexer
     volumes:
       - .:/data
     depends_on:
@@ -16,4 +14,4 @@ services:
 
   redis:
     container_name: triplexer-cache
-    image: "redis:5"
+    image: 'redis:5'


### PR DESCRIPTION
- Removed build directive. Docker-compose now relies on quay.io's compiled image
- Extended PATH environment variable to call triplexer pipeline