### PR TITLE
retrieve genomic sequences from UCSC and DAS

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -199,7 +199,7 @@ def get_supported_namespaces():
     supported_namespaces += line_divider
 
     for k, v in NAMESPACES.items():
-        label, num = v
+        label, source, origing, release, orgagnism, genome = v
         supported_namespaces += "|  {:<1}\t| {:<32} |\n".format(k, v[STRING])
 
     supported_namespaces += line_divider

--- a/common.py
+++ b/common.py
@@ -32,27 +32,53 @@ SEED_MAX_DISTANCE = 35
 #
 STRING = "string"
 SOURCE = "source"
+ORIGIN   = "origin"
+RELEASE  = "release"
+ORGANISM = "organism"
+GENOME   = "genome"
+
 MICRORNA_ORG = "microrna.org"
+
 NAMESPACES = {
     "test": {
         STRING: str(MICRORNA_ORG + ":aug.2010:hsa:hg19"),
-        SOURCE: "data/microrna.org__aug.2010__hsa__hg19.test"
+        SOURCE: "data/microrna.org__aug.2010__hsa__hg19.test",
+        ORIGIN: MICRORNA_ORG,
+        RELEASE:  "aug.2010",
+        ORGANISM: "hsa",
+        GENOME:   "hg19"
     },
     "1": {
         STRING: str(MICRORNA_ORG + ":aug.2010:hsa:hg19"),
-        SOURCE: "https://zenodo.org/record/3870932/files/microrna.org__aug.2010__hsa__hg19.tsv"
+        SOURCE: "https://zenodo.org/record/3870932/files/microrna.org__aug.2010__hsa__hg19.tsv",
+        ORIGIN: MICRORNA_ORG,
+        RELEASE:  "aug.2010",
+        ORGANISM: "hsa",
+        GENOME:   "hg19"
     },
     "2": {
         STRING: str(MICRORNA_ORG + ":aug.2010:mmu:mm9"),
-        SOURCE: "https://zenodo.org/record/3870932/files/microrna.org__aug.2010__mmu__mm9.tsv"
+        SOURCE: "https://zenodo.org/record/3870932/files/microrna.org__aug.2010__mmu__mm9.tsv",
+        ORIGIN: MICRORNA_ORG,
+        RELEASE:  "aug.2010",
+        ORGANISM: "mmu",
+        GENOME:   "mm9"
     },
     "3": {
         STRING: str(MICRORNA_ORG + ":aug.2010:rno:rn4"),
-        SOURCE: "https://zenodo.org/record/3870932/files/microrna.org__aug.2010__rno__rn4.tsv"
+        SOURCE: "https://zenodo.org/record/3870932/files/microrna.org__aug.2010__rno__rn4.tsv",
+        ORIGIN: MICRORNA_ORG,
+        RELEASE:  "aug.2010",
+        ORGANISM: "rno",
+        GENOME:   "rn4"
     },
     "4": {
         STRING: str(MICRORNA_ORG + ":aug.2010:dme:dm3"),
-        SOURCE: "https://zenodo.org/record/3870932/files/microrna.org__aug.2010__dme__dm3.tsv"
+        SOURCE: "https://zenodo.org/record/3870932/files/microrna.org__aug.2010__dme__dm3.tsv",
+        ORIGIN: MICRORNA_ORG,
+        RELEASE:  "aug.2010",
+        ORGANISM: "dme",
+        GENOME:   "dm3"
     }
 }
 

--- a/triplexer
+++ b/triplexer
@@ -14,12 +14,10 @@ from common import *
 
 
 # logger
+#
 logger = logging.getLogger(TRIPLEXER)
 
-
-
 # file logger
-#
 LOGFILE = FILE_PATH.joinpath(str(TRIPLEXER + FILE_EXT_LOG))
 logging.basicConfig(
     level = logging.DEBUG,
@@ -28,10 +26,7 @@ logging.basicConfig(
     filename = LOGFILE,
     filemode = "w")
 
-
-
 # console logger
-#
 console = logging.StreamHandler()
 console.setLevel(logging.INFO)
 formatter = logging.Formatter("%(message)s")


### PR DESCRIPTION
- Modified the filtrate operation to cache _gene targets IDs_ alongside transcript IDs
- Added a function to retrieve the genomic sequence of a target gene from the [UCSC](https://genome.ucsc.edu/goldenpath/help/mysql.html) (MySQL interface) and [DAS](https://genome.ucsc.edu/cgi-bin/das/) server