### PR TITLE
Ns specific ops

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -53,12 +53,40 @@ OPT_ANNOTATE_SHORT   = str("-" + OPT_ANNOTATE[:1])
 OPT_ANNOTATE_EXT     = str("--" + OPT_ANNOTATE)
 
 # all operations
-OPS = [
-    OPT_INIT_NS,
-    OPT_READ,
-    OPT_FILTRATE,
-    OPT_ANNOTATE
-]
+#
+# NOTE: ADD NEW NAMESPACES-SPECIFIC-OPERATIONS IN THE FOLLOWING DICTIONARY
+# The triplexer identifies 3 abstract operations:
+# - read        for reading an input file containing miRNA duplexes
+# - filtrate    for keeping only those miRNA duplexes that bind a common target
+#               gene in compliance with defined structural constraints
+# - annotate    to retrieve the target gene's transcript sequence from a remote
+#               database
+# Since the identification of putative RNA triplexes is carried out by
+# harvesting data from different sources (namespace, e.g. microrna.org,
+# TargetScan, etc.), it is safe to assume that input datasets have a different
+# organization, i.e. duplex information in a microrna.org file are not the same
+# as those found in a TargetScan dataset. Hence, the implementation and
+# combination of each operations is "namespace-specific".
+# For example, to find putative RNA triplexes in a microrna.org dataset, one
+# needs to run:
+# - a namespace-specific implementation of the operation read
+# - a namespace-agnostic implementation of the operation filtrate
+# - a namespace-agnostic implementation of the operation annotate
+# However, to find putative RNA triplexes from a different namespace, one might
+# need to instead run:
+# - a namespace-specific implementation of the operation read
+# - the same namespace-agnostic implementation of the operation filtrate
+# - no operation annotate
+# For this reason, we collect the set of all namespace-specific-operations
+# in the following dictionary
+OPS = {
+    MICRORNA_ORG: [
+        OPT_INIT_NS,
+        OPT_READ,
+        OPT_FILTRATE,
+        OPT_ANNOTATE
+    ]
+}
 
 
 

--- a/triplexer
+++ b/triplexer
@@ -105,8 +105,14 @@ if __name__ == "__main__":
         sys.exit(2)
 
 
-    # launch all operations given on the CLI
-    for op in OPS:
+    # launch all namespace-sepcific-operations given on the CLI
+    ns_code = cli_args[OPT_NAMESPACE]
+    ns = NAMESPACES[ns_code][NS_LABEL].split(SEPARATOR)[0]
+
+    for op in OPS[ns]:
         if op in cli_args.keys():
-            run(op, cli_args)
+            logger.info("Operation \"%s\" started", op)
+            launch[ns][op](cache, cli_args)
+            logger.info("Operation \"%s\" completed", op)
+#            run(op, cli_args)
 

--- a/triplexer
+++ b/triplexer
@@ -48,22 +48,6 @@ launch = {
 
 
 
-# run the operation
-#
-def run(operation, cli_args):
-    """
-    Runs an operation.
-    """
-
-    ns_code = cli_args[OPT_NAMESPACE]
-    ns = NAMESPACES[ns_code][NS_LABEL].split(SEPARATOR)[0]
-
-    logger.info("Operation \"%s\" started", operation)
-    launch[ns][operation](cache, cli_args)
-    logger.info("Operation \"%s\" completed", operation)
-
-
-
 # main
 #
 if __name__ == "__main__":
@@ -114,5 +98,4 @@ if __name__ == "__main__":
             logger.info("Operation \"%s\" started", op)
             launch[ns][op](cache, cli_args)
             logger.info("Operation \"%s\" completed", op)
-#            run(op, cli_args)
 


### PR DESCRIPTION
The triplexer identifies 3 abstract operations:
- **read** for reading an input file containing miRNA duplexes
- **filtrate** for keeping only those miRNA duplexes that bind a common target gene in compliance with defined structural constraints
- **annotate** to retrieve the target gene's transcript sequence from a remote database

Since the identification of putative RNA triplexes is carried out by harvesting data from different sources (namespace, e.g. microrna.org, TargetScan, etc.), it is safe to assume that input datasets have a different organization, i.e. duplex information in a microrna.org file are not the same as those found in a TargetScan dataset. Hence, the implementation and combination of each operations is _namespace-specific_.
For example, to find putative RNA triplexes in a microrna.org dataset, one needs to run:
- a namespace-specific implementation of the operation read
- a namespace-agnostic implementation of the operation filtrate
- a namespace-agnostic implementation of the operation annotate

However, to find putative RNA triplexes from a different namespace, one might need to instead run:
- a namespace-specific implementation of the operation read
- the same namespace-agnostic implementation of the operation filtrate
- no operation annotate

For this reason, operations are redefined as namespace-specific-operations. Each namespace will therefore define its own set of operations that are necessary to identify putative RNA triplexes.