### PR TITLE
removed ns initialization

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -34,19 +34,6 @@ OPT_FILTRATE         = "filtrate"
 OPT_FILTRATE_SHORT   = str("-" + OPT_FILTRATE[:1])
 OPT_FILTRATE_EXT     = str("--" + OPT_FILTRATE)
 
-# init namespaces
-OPT_INIT_NS         = "init_ns"
-OPT_INIT_NS_SHORT   = str("-" + OPT_INIT_NS[:1])
-OPT_INIT_NS_EXT     = str("--" + OPT_INIT_NS)
-OPT_INIT_NS_SAME_AS = [
-    OPT_READ,
-    OPT_FILTRATE
-]
-OPT_INIT_NS_SAME_AS_CLI = [
-    OPT_READ_SHORT,
-    OPT_FILTRATE_SHORT
-]
-
 # annotate
 OPT_ANNOTATE         = "annotate"
 OPT_ANNOTATE_SHORT   = str("-" + OPT_ANNOTATE[:1])
@@ -81,7 +68,6 @@ OPT_ANNOTATE_EXT     = str("--" + OPT_ANNOTATE)
 # in the following dictionary
 OPS = {
     MICRORNA_ORG: [
-        OPT_INIT_NS,
         OPT_READ,
         OPT_FILTRATE,
         OPT_ANNOTATE
@@ -121,7 +107,7 @@ def triplexer_parser():
         type=argparse.FileType("r"),
         help="set %(metavar)s as configuration file")
 
-    # cores
+    # multiprocessing
     parser.add_argument(
         OPT_EXE_SHORT,
         OPT_EXE_EXT,
@@ -165,15 +151,6 @@ def triplexer_parser():
         action="store_true",
         default=argparse.SUPPRESS,
         help=str("annotate transcripts with their sequences"))
-
-    parser_op.add_argument(
-        OPT_INIT_NS_SHORT,
-        OPT_INIT_NS_EXT,
-        action="store_true",
-        default=argparse.SUPPRESS,
-        help=str("initialize the cache with putative RNA triplexes\n"
-            + "(same as " + " ".join( str(x) for x in OPT_INIT_NS_SAME_AS_CLI)
-            + ")"))
     #
     # operation arguments end
 

--- a/microrna_org.py
+++ b/microrna_org.py
@@ -107,25 +107,6 @@ def annotate(cache, options):
 
 
 
-# initialize the microrna.org namespace by triggering the read and filtrate
-# operations
-#
-def init_ns(cache, options):
-    """
-    Initializes the microrna.org namespace by: 1) reading its predicted RNA
-    duplexes (operation read); 2) keep each duplex pair whose seed-binding
-    distance resides within the allowed nt. range (Saetrom et al. 2007)
-    (operation filtrate).
-    """
-
-    # operation read
-    read(cache, options)
-
-    # operation filtrate
-    filtrate(cache, options)
-
-
-
 # crawl UCSC to retrieve the genomic sequence of a cached target gene:
 # - fetch the next target gene
 # - create a Bio.SeqRecord object to store its RefSeq ID and genome build

--- a/triplexer
+++ b/triplexer
@@ -39,7 +39,6 @@ logging.getLogger("").addHandler(console)
 #
 launch = {
     MICRORNA_ORG : {
-        OPT_INIT_NS: microrna_org.init_ns,
         OPT_READ: microrna_org.read,
         OPT_FILTRATE: microrna_org.filtrate,
         OPT_ANNOTATE: microrna_org.annotate


### PR DESCRIPTION
Removed init ns operation that spawned read and filtrate to simplify the CLI.
The read and filtrate operations can in fact be called via CLI with their flags -r and -f respectively, which make the CLI invocation more readable.